### PR TITLE
chore: Update documentation

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,10 +6,10 @@ git_release_enable = false
 [[package]]
 name = "structable"
 git_release_enable = true
+changelog_include = ["structable_derive"]
 version_group = "structable"
 
 [[package]]
 name = "structable_derive"
-changelog_include = ["structable"]
 git_release_enable = true
 version_group = "structable"

--- a/structable/src/lib.rs
+++ b/structable/src/lib.rs
@@ -124,8 +124,17 @@
 //!     }
 //! }
 //! ```
+//!  ## Field parameters
 //!
-//! Example
+//!  - `title` column name to be returned. When unset field name is used.
+//!
+//!  - `wide` return field only in the `wide` mode, or when explicitly requested through `fields`
+//!
+//!  - `serialize` serialize field value to the json. When `pretty` mode is requested uses
+//!  `to_pretty_string()`
+//!
+//!
+//! ## Example
 //!
 //! ```rust
 //! # use std::collections::BTreeSet;
@@ -188,9 +197,6 @@
 //! multiple user ["id", "first_name", "last_name", "long_only"] => [["1", "Scooby", "Doo", "Foo"], ["2", "John", "Cena", "Bar"]]
 //! ```
 //!
-//!
-//!
-
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 


### PR DESCRIPTION
- update crate doc with field parameters
- alter releases so that structable includes changelog of the
  structable_derive and not vice-versa.
