### PR TITLE
fix: Trip quotes for serialized field in values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/structable/src/lib.rs
+++ b/structable/src/lib.rs
@@ -524,10 +524,12 @@ mod tests {
             Some("foo".into())
         );
     }
+
     #[test]
     fn test_single_no_status() {
         assert_eq!(User::default().status(), None);
     }
+
     #[test]
     fn test_single_option_status() {
         assert_eq!(
@@ -556,7 +558,25 @@ mod tests {
             .status(),
             Some("Dummy".into())
         );
+
+        let (_, rows) = build_table(
+            &SerializeOptionStatusStruct {
+                status: Some(Status::Dummy),
+            },
+            &OutputConfig::default(),
+        );
+        assert_eq!(vec![vec!["status".to_string(), "Dummy".to_string()]], rows);
+
+        let (_, rows) = build_list_table(
+            [SerializeOptionStatusStruct {
+                status: Some(Status::Dummy),
+            }]
+            .iter(),
+            &OutputConfig::default(),
+        );
+        assert_eq!(vec![vec!["Dummy".to_string()]], rows);
     }
+
     #[test]
     fn test_status() {
         #[derive(Deserialize, Serialize, StructTable)]

--- a/structable_derive/src/structable.rs
+++ b/structable_derive/src/structable.rs
@@ -103,7 +103,9 @@ impl ToTokens for TableStructInputReceiver {
                                 serde_json::to_string_pretty(&self. #field_ident)
                             } else {
                                 serde_json::to_string(&self. #field_ident)
-                            }.unwrap_or_else(|_| String::from("<ERROR SERIALIZING DATA>"))
+                            }
+                                .map(|x| x.trim_matches('"').to_string())
+                                .unwrap_or_else(|_| String::from("<ERROR SERIALIZING DATA>"))
                             )
                         ),
                     },
@@ -119,7 +121,9 @@ impl ToTokens for TableStructInputReceiver {
                                         serde_json::to_string_pretty(&v)
                                     } else {
                                         serde_json::to_string(&v)
-                                    }.unwrap_or_else(|_| String::from("<ERROR SERIALIZING DATA>"))
+                                    }
+                                        .map(|x| x.trim_matches('"').to_string())
+                                        .unwrap_or_else(|_| String::from("<ERROR SERIALIZING DATA>"))
                                 )
                         ),
                     },


### PR DESCRIPTION
Trim the quotes wrapping the "serialize" attribute not only in status
output, but also in the regular table.
