### PR TITLE
fix: Prevent necessity to import serde_json::Value

### DIFF
--- a/structable/src/lib.rs
+++ b/structable/src/lib.rs
@@ -860,6 +860,17 @@ mod tests {
             a: Value,
             #[structable(optional, serialize)]
             b: Option<Value>,
+            #[structable(serialize)]
+            c: NestedData,
+        }
+
+        #[derive(Clone, Deserialize, Serialize)]
+        struct NestedData {
+            b: NestedData2,
+        }
+        #[derive(Clone, Deserialize, Serialize)]
+        struct NestedData2 {
+            c: String,
         }
 
         let config = CustomConfig {
@@ -868,6 +879,9 @@ mod tests {
         let sot = Data {
             a: json!({"b": {"c": "d", "e": "f"}}),
             b: Some(json!({"b": {"c": "x", "e": "f"}})),
+            c: NestedData {
+                b: NestedData2 { c: "x".to_string() },
+            },
         };
         assert_eq!(
             build_table(&sot, &config),
@@ -876,6 +890,7 @@ mod tests {
                 vec![
                     vec!["a".to_string(), "d".to_string()],
                     vec!["b".to_string(), "x".to_string()],
+                    vec!["c".to_string(), "x".to_string()],
                 ]
             ),
         );

--- a/structable_derive/src/structable.rs
+++ b/structable_derive/src/structable.rs
@@ -105,7 +105,7 @@ impl ToTokens for TableStructInputReceiver {
                                             .field_data_json_pointer(#field_title)
                                             .map_or(
                                                 v.to_owned(),
-                                                |jp| {v.pointer(jp.as_ref()).unwrap_or(&Value::Null).to_owned()}
+                                                |jp| {v.pointer(jp.as_ref()).unwrap_or(&serde_json::Value::Null).to_owned()}
                                             )
                                     })
                                     .and_then(|v| {
@@ -134,7 +134,7 @@ impl ToTokens for TableStructInputReceiver {
                                                 .field_data_json_pointer(#field_title)
                                                 .map_or(
                                                     v.to_owned(),
-                                                    |jp| {v.pointer(jp.as_ref()).unwrap_or(&Value::Null).to_owned()}
+                                                    |jp| {v.pointer(jp.as_ref()).unwrap_or(&serde_json::Value::Null).to_owned()}
                                                 )
                                         })
                                         .and_then(|v| {


### PR DESCRIPTION
When inside the macros `Value` is being used that requires serde_json to
be imported. It is not a great UX so instead use `serde_json::Value`
explicitly.
Add some more nested tests without direct Value usage.
