### PR TITLE
chore: Raise the low version of rust for clippy job

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  rust_ver: 1.76
+  rust_ver: 1.78
 
 jobs:
   rustfmt:


### PR DESCRIPTION
1.76 rust can not be used in clippy jobs due to the raised clippy-sarif rust dependency.